### PR TITLE
Fix buffering that occurs when shell commands are logged

### DIFF
--- a/src/rootsh.c
+++ b/src/rootsh.c
@@ -952,7 +952,7 @@ int beginlogging(const char *shellCommands) {
 
   if(NULL != shellCommands) {
     msglen = snprintf(msgbuf, (sizeof(msgbuf) - 1),
-                      "shell commands: %s\n", shellCommands);
+                      "shell commands: %s\r\n", shellCommands);
     dologging(msgbuf, msglen);
   }
 


### PR DESCRIPTION
When there are shell commands that are logged, the shell commands + first command are incorrectly buffered together and we generate a single resulting log line:

```
May  8 16:47:22.701 myhost rootsh[186397]: chris.boulton: shell commands: /usr/bin/commandhere
inputinputinput
```

This occurs because of the buffering that occurs in `write2syslog` and the `shell commands..` logging doesn't send a carriage return. With one being sent, we get two events:

```
2025-05-08T18:08:52.949389+00:00 myhost rootsh[3045490]: chris.boulton: shell commands: /usr/bin/commandhere
2025-05-08T18:08:57.943248+00:00 myhost rootsh[3045490]: chris.boulton: inputinputinput
```